### PR TITLE
fix(template): allow for colon to terminate a template

### DIFF
--- a/lib/parse-path-template.js
+++ b/lib/parse-path-template.js
@@ -1,7 +1,7 @@
 // helper
 module.exports = function (src, variables = {}, defaults = {}) {
   // find all parameters
-  const results = src.matchAll(/\{(?<param>[^/]+)\}/g)
+  const results = src.matchAll(/\{(?<param>[^/:]+)\}/g)
 
   for (const { groups: { param } } of results) {
     const regex = new RegExp(`{${param}}`, 'g')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1917,15 +1917,15 @@
       "integrity": "sha512-7g9WaBK8Cp3f3Ry+OFTwhDjnEjJGGsylOT3V7N+hcONYgSpnhbgVp9ZIyAt++YTwBkRrE/6NxKCCf0MbSiToCg==",
       "dev": true,
       "requires": {
-        "@types/react": "*",
+        "@types/react": "^17",
         "chokidar": "^3.3.0",
         "coveralls": "^3.0.11",
         "findit": "^2.0.0",
         "foreground-child": "^2.0.0",
         "fs-exists-cached": "^1.0.0",
         "glob": "^7.1.6",
-        "import-jsx": "*",
-        "ink": "*",
+        "import-jsx": "import-jsx@4.0.0",
+        "ink": "^3.2.0",
         "isexe": "^2.0.0",
         "istanbul-lib-processinfo": "^2.0.2",
         "jackspeak": "^1.4.1",
@@ -1934,7 +1934,7 @@
         "mkdirp": "^1.0.4",
         "nyc": "^15.1.0",
         "opener": "^1.5.1",
-        "react": "*",
+        "react": "^17.0.2",
         "rimraf": "^3.0.0",
         "signal-exit": "^3.0.0",
         "source-map-support": "^0.5.16",
@@ -1942,7 +1942,7 @@
         "tap-parser": "^10.0.1",
         "tap-yaml": "^1.0.0",
         "tcompare": "^5.0.6",
-        "treport": "*",
+        "treport": "^3.0.0",
         "which": "^2.0.2"
       },
       "dependencies": {
@@ -2540,6 +2540,7 @@
         },
         "import-jsx": {
           "version": "4.0.0",
+          "from": "import-jsx@4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {

--- a/test/index.js
+++ b/test/index.js
@@ -45,7 +45,7 @@ test('methods are callable', assert => {
 
   fetch.callsFake((url, options) => {
     assert.match(url, new URL('http://pets.com/pets/%7BpetId%7D'))
-    assert.deepEqual(options, {
+    assert.same(options, {
       method: 'get',
       headers: {}
     })
@@ -62,7 +62,7 @@ test('methods options', assert => {
 
   fetch.callsFake((url, options) => {
     assert.match(url, new URL('https://pets.com/pets/1'))
-    assert.deepEqual(options, {
+    assert.same(options, {
       method: 'get',
       headers: {}
     })
@@ -83,7 +83,7 @@ test('global defaults', assert => {
 
   fetch.callsFake((url, options) => {
     assert.match(url, new URL('https://pets.com/pets/1?name=ruby&is_good=yes'))
-    assert.deepEqual(options, {
+    assert.same(options, {
       method: 'get',
       headers: { 'x-pet-type': 'dog' }
     })

--- a/test/parse-server.js
+++ b/test/parse-server.js
@@ -102,3 +102,25 @@ test('populates the server.url with server.variables', assert => {
 
   assert.equal(parseServer({ url: 'localhost/{foo}', variables: { foo: 'bar' } }, spec), 'localhost/bar')
 })
+
+test('populates the server.url with server.variables with colons', assert => {
+  assert.plan(1)
+
+  const spec = {
+    servers: [{
+      url: 'localhost',
+      variables: { foo: {} }
+    }]
+  }
+
+  assert.equal(parseServer({
+    url: '{protocol}://{host}:{port}/{path1}/{path2}',
+    variables: {
+      protocol: 'ftp',
+      host: 'localhost',
+      port: '8080',
+      path1: 'path1',
+      path2: 'path2'
+    }
+  }, spec), 'ftp://localhost:8080/path1/path2')
+})


### PR DESCRIPTION
This PR introduces a fix to allow a colon to terminate a template.

This mainly allow for templates like: `http://{host}:{port}/`