### PR TITLE
feat: allow parameter detection even if there is a query param

### DIFF
--- a/lib/parse-path-template.js
+++ b/lib/parse-path-template.js
@@ -1,7 +1,7 @@
 // helper
 module.exports = function (src, variables = {}, defaults = {}) {
   // find all parameters
-  const results = src.matchAll(/\{(?<param>[^/:]+)\}/g)
+  const results = src.matchAll(/\{(?<param>[^/:?]+)\}/g)
 
   for (const { groups: { param } } of results) {
     const regex = new RegExp(`{${param}}`, 'g')

--- a/test/parse-path-template.js.js
+++ b/test/parse-path-template.js.js
@@ -7,6 +7,7 @@ test('parse path templates', assert => {
 
   assert.equal(parsePathTemplate('/pets/{petId}'), '/pets/{petId}', 'keep variable template if no variables present')
   assert.equal(parsePathTemplate('/pets/{petId}', { petId: 'foo' }), '/pets/foo', 'replaces one value')
+  assert.equal(parsePathTemplate('/pets/{petId}?deleted=false', { petId: 'foo' }), '/pets/foo', 'replaces one value even if a query parameter is provided')
   assert.equal(parsePathTemplate('/{entity}/{id}', { entity: 'pet', id: '123' }), '/pet/123', 'replaces all the value')
   assert.equal(parsePathTemplate('/{entity}/{id}/{id}', { entity: 'pet', id: '123' }), '/pet/123/123', 'replaces the same value multiple times')
 })


### PR DESCRIPTION
When a URL contains a query string right after a parameter, the parameter is not detected correctly and the `matchAll` returns the parameter and the query string together.

This PR fixes it.

Example:

```plaintext
PATCH http://my.site.com/users/{userId}?deleted=false
```

Now correctly detects `{userId}`.

Previously it would match: `{userId}?deleted=false`